### PR TITLE
gedit 3.8 compatibility

### DIFF
--- a/restoretabs.plugin.python2
+++ b/restoretabs.plugin.python2
@@ -1,5 +1,5 @@
 [Plugin]
-Loader=python3
+Loader=python
 Module=restoretabs
 IAge=3
 Name=Restore Tabs

--- a/restoretabs.py
+++ b/restoretabs.py
@@ -81,7 +81,10 @@ class RestoreTabsWindowActivatable(GObject.Object, Gedit.WindowActivatable):
         Close the first tab if it is empty.
         """
         if tab.get_state() == Gedit.TabState.STATE_NORMAL and tab.get_document().is_untouched():
-            (GLib if hasattr(GLib, "idle_add") else GObject).idle_add(window.close_tab, tab)
+            def close_tab():
+                window.close_tab(tab)
+                return False
+            (GLib if hasattr(GLib, "idle_add") else GObject).idle_add(close_tab)
         if self._temp_handler is not None:
             window.disconnect(self._temp_handler)
             self._temp_handler = None

--- a/restoretabs.py
+++ b/restoretabs.py
@@ -59,6 +59,7 @@ class RestoreTabsWindowActivatable(GObject.Object, Gedit.WindowActivatable):
         """
         Only restore tabs if this window is the first Gedit window instance.
         """
+        self.window.disconnect(self._temp_handler)
         if self.is_first_window():
             tab = self.window.get_active_tab()
             if tab.get_state() == 0 and not tab.get_document().get_location():
@@ -69,5 +70,4 @@ class RestoreTabsWindowActivatable(GObject.Object, Gedit.WindowActivatable):
                 if not tab:
                     self.window.create_tab_from_location(location, None, 0, 
                                                          0, False, True)
-            self.window.disconnect(self._temp_handler)
 

--- a/restoretabs.py
+++ b/restoretabs.py
@@ -78,7 +78,7 @@ class RestoreTabsWindowActivatable(GObject.Object, Gedit.WindowActivatable):
 
     def on_tab_added(self, window, tab):
         if tab.get_state() == 0 and not tab.get_document().get_location():
-            window.close_tab(tab)
+            (GLib if hasattr(GLib, "idle_add") else GObject).idle_add(window.close_tab, tab)
         if self._temp_handler is not None:
             window.disconnect(self._temp_handler)
             self._temp_handler = None

--- a/restoretabs.py
+++ b/restoretabs.py
@@ -77,6 +77,9 @@ class RestoreTabsWindowActivatable(GObject.Object, Gedit.WindowActivatable):
                 self._temp_handler = window.connect("tab-added", self.on_tab_added)
 
     def on_tab_added(self, window, tab):
+        """
+        Close the first tab if it is empty.
+        """
         if tab.get_state() == Gedit.TabState.STATE_NORMAL and tab.get_document().is_untouched():
             (GLib if hasattr(GLib, "idle_add") else GObject).idle_add(window.close_tab, tab)
         if self._temp_handler is not None:

--- a/restoretabs.py
+++ b/restoretabs.py
@@ -84,7 +84,10 @@ class RestoreTabsWindowActivatable(GObject.Object, Gedit.WindowActivatable):
             def close_tab():
                 window.close_tab(tab)
                 return False
-            (GLib if hasattr(GLib, "idle_add") else GObject).idle_add(close_tab)
+            try:
+                GLib.idle_add(close_tab)
+            except TypeError:
+                GObject.idle_add(close_tab)
         if self._temp_handler is not None:
             window.disconnect(self._temp_handler)
             self._temp_handler = None

--- a/restoretabs.py
+++ b/restoretabs.py
@@ -20,8 +20,11 @@ class RestoreTabsWindowActivatable(GObject.Object, Gedit.WindowActivatable):
                                          self.on_window_delete_event)                             
         self._handlers.append(handler_id)
         
-        # temporary handler to catch the first time a window is shown
-        self._temp_handler = self.window.connect("show", self.on_window_show)  
+        settings = Gio.Settings.new(SETTINGS_SCHEMA)
+        uris = settings.get_value('uris')
+        if uris:
+            # temporary handler to catch the first time a window is shown
+            self._temp_handler = self.window.connect("show", self.on_window_show, uris)
 
     def do_deactivate(self):
         """
@@ -52,7 +55,7 @@ class RestoreTabsWindowActivatable(GObject.Object, Gedit.WindowActivatable):
         settings.set_value('uris', GLib.Variant("as", uris))
         return False
     
-    def on_window_show(self, window, data=None):
+    def on_window_show(self, window, uris):
         """
         Only restore tabs if this window is the first Gedit window instance.
         """
@@ -60,14 +63,11 @@ class RestoreTabsWindowActivatable(GObject.Object, Gedit.WindowActivatable):
             tab = self.window.get_active_tab()
             if tab.get_state() == 0 and not tab.get_document().get_location():
                 self.window.close_tab(tab)
-            settings = Gio.Settings.new(SETTINGS_SCHEMA)
-            uris = settings.get_value('uris')
-            if uris:
-                for uri in uris:
-                    location = Gio.file_new_for_uri(uri)
-                    tab = self.window.get_tab_from_location(location)
-                    if not tab:
-                        self.window.create_tab_from_location(location, None, 0, 
-                                                             0, False, True)
+            for uri in uris:
+                location = Gio.file_new_for_uri(uri)
+                tab = self.window.get_tab_from_location(location)
+                if not tab:
+                    self.window.create_tab_from_location(location, None, 0, 
+                                                         0, False, True)
             self.window.disconnect(self._temp_handler)
 

--- a/restoretabs.py
+++ b/restoretabs.py
@@ -77,7 +77,7 @@ class RestoreTabsWindowActivatable(GObject.Object, Gedit.WindowActivatable):
                 self._temp_handler = window.connect("tab-added", self.on_tab_added)
 
     def on_tab_added(self, window, tab):
-        if tab.get_state() == 0 and not tab.get_document().get_location():
+        if tab.get_state() == Gedit.TabState.STATE_NORMAL and tab.get_document().is_untouched():
             (GLib if hasattr(GLib, "idle_add") else GObject).idle_add(window.close_tab, tab)
         if self._temp_handler is not None:
             window.disconnect(self._temp_handler)


### PR DESCRIPTION
This updates the code to be compatible with gedit 3.8:
-   Updated .plugin file (with a separate .plugin file for gedit <= 3.6).
-   Fixed empty tab closing on launch. This should also be compatible with gedit <= 3.6, though I haven't tested it yet.

Would be great if this is merged soon as I have some other ideas I'd like to implement after this :-)
